### PR TITLE
Stop tests in GHA when these become fast

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,21 +23,25 @@ jobs:
       with:
         go-version: '1.16'
 
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build
+      run:
+        make build
+
+    # - name: Login to GitHub Container Registry
+    #   uses: docker/login-action@v1
+    #   with:
+    #     registry: ghcr.io
+    #     username: ${{ github.repository_owner }}
+    #     password: ${{ secrets.GITHUB_TOKEN }}
 
     # Setup tmate session to debug via SSH. See https://github.com/mxschmitt/action-tmate
     # - uses: mxschmitt/action-tmate@v1
 
-    - name: make clean-e2e-test
-      run: |
-        make clean-e2e-test IMG=${DOCKER_IMAGE_URI}:${DOCKER_TAG}
+    # - name: make clean-e2e-test
+    #   run: |
+    #     make clean-e2e-test IMG=${DOCKER_IMAGE_URI}:${DOCKER_TAG}
 
-    - name: make docker-push
-      if: github.event_name == 'push'
-      run: |
-        make docker-push IMG=${DOCKER_IMAGE_URI}:${DOCKER_TAG}
+    # - name: make docker-push
+    #   if: github.event_name == 'push'
+    #   run: |
+    #     make docker-push IMG=${DOCKER_IMAGE_URI}:${DOCKER_TAG}


### PR DESCRIPTION
Temporarily stop the testing by GHA. This is because it takes a very long time and is costly. I'm going to do another PR to speed up the process, so we will stop testing with CI until then.