### PR TITLE
Fix pushing ci flow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -58,12 +58,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Get the Tag Name
-        id: get-tag
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
-      - name: Show the Container Image URI
-        run: echo ${CONTAINER_IMAGE_REPOSITORY}:${{ steps.get-tag.outputs.tag }}
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         with:
@@ -74,11 +68,23 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.CONTAINER_IMAGE_REPOSITORY }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=tag
+            type=schedule,pattern={{date 'YYYYMMDD'}}
+            type=sha
       - name: Build and Push
         uses: docker/build-push-action@v2
         with:
           context: .
           push: true
-          tags: ${{ env.CONTAINER_IMAGE_REPOSITORY }}:${{ steps.get-tag.outputs.tag }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
* Fix the login user for the `ghcr.io` registry.
* I reconfigure the CI flow with the reference to [starter-workflow](https://github.com/actions/starter-workflows/blob/29e8b6c/ci/docker-publish.yml).
    * Use [docker-metadata](https://github.com/docker/metadata-action) action to add more informative tags & labels.