### PR TITLE
Support metadata field (`ObjectMeta`) 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= fluent-pvc-operator:development
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false,maxDescLen=0"
+CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false,maxDescLen=0,generateEmbeddedObjectMeta=true"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/config/crd/bases/fluent-pvc-operator.tech.zozo.com_fluentpvcbindings.yaml
+++ b/config/crd/bases/fluent-pvc-operator.tech.zozo.com_fluentpvcbindings.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: fluentpvcbindings.fluent-pvc-operator.tech.zozo.com
 spec:

--- a/config/crd/bases/fluent-pvc-operator.tech.zozo.com_fluentpvcs.yaml
+++ b/config/crd/bases/fluent-pvc-operator.tech.zozo.com_fluentpvcs.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: fluentpvcs.fluent-pvc-operator.tech.zozo.com
 spec:
@@ -296,6 +296,23 @@ spec:
                         volumeClaimTemplate:
                           properties:
                             metadata:
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                finalizers:
+                                  items:
+                                    type: string
+                                  type: array
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
                               type: object
                             spec:
                               properties:
@@ -824,6 +841,23 @@ spec:
                   template:
                     properties:
                       metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          finalizers:
+                            items:
+                              type: string
+                            type: array
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          name:
+                            type: string
+                          namespace:
+                            type: string
                         type: object
                       spec:
                         properties:
@@ -3257,6 +3291,23 @@ spec:
                                     volumeClaimTemplate:
                                       properties:
                                         metadata:
+                                          properties:
+                                            annotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            finalizers:
+                                              items:
+                                                type: string
+                                              type: array
+                                            labels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
                                           type: object
                                         spec:
                                           properties:


### PR DESCRIPTION
* The metadata field was not defined correctly in CRD, and any value set to metadata was ignored.
* `controller-tools` has fixed this problem, so I upgraded the version of `controller-gen` to use CRD's definition.
    * ref. https://github.com/kubernetes-sigs/controller-tools/pull/557