### PR TITLE
Ship 0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.0.2 (2021-09-17)
+==================
+
+- [#21](https://github.com/st-tech/fluent-pvc-operator/pull/21) Support metadata field (`ObjectMeta`) 
+
 0.0.1 (2021-09-09)
 ==================
 


### PR DESCRIPTION
- [#21](https://github.com/st-tech/fluent-pvc-operator/pull/21) Support metadata field (`ObjectMeta`) 
