### PR TITLE
Add from_encoding:UTF-8 to examples/log-collection/fluentd/fluent.conf

### DIFF
--- a/examples/log-collection/fluentd/fluent.conf
+++ b/examples/log-collection/fluentd/fluent.conf
@@ -28,6 +28,7 @@
     read_from_head               true
     follow_inodes                true
     refresh_interval             "#{ENV.fetch('FLUENTD_IN_TAIL_REFRESH_INTERVAL')}"
+    # NOTE: Input is supposed to be UTF-8 encoded and expect in-tail to emit the input as UTF-8 string.
     from_encoding                UTF-8
     encoding                     UTF-8
     pos_file                     "#{File.join(ENV.fetch('FLUENTD_BUFFER_DIR'), 'event.log.pos')}"

--- a/examples/log-collection/fluentd/fluent.conf
+++ b/examples/log-collection/fluentd/fluent.conf
@@ -28,6 +28,7 @@
     read_from_head               true
     follow_inodes                true
     refresh_interval             "#{ENV.fetch('FLUENTD_IN_TAIL_REFRESH_INTERVAL')}"
+    from_encoding                UTF-8
     encoding                     UTF-8
     pos_file                     "#{File.join(ENV.fetch('FLUENTD_BUFFER_DIR'), 'event.log.pos')}"
     pos_file_compaction_interval 24h


### PR DESCRIPTION
Add `from_encoding UTF-8` to examples/log-collection/fluentd/fluent.conf

- **in_tail** plugin has `from_encoding` option. This is different from `enconding`.
- Now only `encoding UTF-8` is set in **in_tail**.
- This means `Input is ASCII-8BIT and output is UTF-8`, not `Both are UTF-8`.
  - because **in_tail** emits string value as ASCII-8BIT.
  - https://docs.fluentd.org/input/tail#encoding-from_encoding
- In order to make it easier to understand, add `from_encoding UTF-8` 

I want to use fluentd image that has this fluent.conf. Could you release v0.0.3? 