### PR TITLE
Remove CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,0 @@
-0.0.2 (2021-09-17)
-==================
-
-- [#21](https://github.com/st-tech/fluent-pvc-operator/pull/21) Support metadata field (`ObjectMeta`) 
-
-0.0.1 (2021-09-09)
-==================
-
-- First release.

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ $ make examples/log-collection/clean-deploy
 
 ## CHANGELOG
 
-[CHANGELOG.md](./CHANGELOG.md)
+Please see the [list of releases](https://github.com/st-tech/fluent-pvc-operator/releases) for information on changes between releases.
 
 ## License
 


### PR DESCRIPTION
We started to use [Automatically generated release notes](https://github.blog/2021-10-04-beta-github-releases-improving-release-experience/) and stopped writing CHANGELOG manually.