### PR TITLE
Support auto release generation in CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'support-auto-release-creation-in-ci'
     tags:
       - '*'
   pull_request:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'support-auto-release-creation-in-ci'
     tags:
       - '*'
   pull_request:
@@ -88,3 +89,19 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Get Tag Name
+        id: get_tag
+        run: |
+          echo ::set-output name=TAG::${GITHUB_REF#refs/tags/}
+      - name: Create release YAML
+        run: |
+          make manifests-release IMG=$CONTAINER_IMAGE_REPOSITORY:${{ steps.get_tag.outputs.TAG }}
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ steps.get_tag.outputs.TAG }}
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+          files: fluent-pvc-operator.yaml

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ manifests: bin/controller-gen ## Generate WebhookConfiguration, ClusterRole and 
 generate: bin/controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
+manifests-release: manifests bin/kustomize  ## Generate all-in-one manifest for release
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	$(KUSTOMIZE) build config/default > fluent-pvc-operator.yaml
+
 fmt: ## Run go fmt against code.
 	go fmt ./...
 


### PR DESCRIPTION
# Description

Updates the release CI to support the following

- create release 
- add auto generate release note
- upload all-in-manifest to the release

# Test

I've setup [dummy trigger](https://github.com/st-tech/fluent-pvc-operator/pull/30/commits/60f31bd23a0014af502d6cdefdebfa317b35005f) in CI and I've tagged with dummy one v0.0.4-alpha and got an expected result like this:

- release url: https://github.com/st-tech/fluent-pvc-operator/releases/tag/v0.0.4-alpha
- action url:  https://github.com/st-tech/fluent-pvc-operator/runs/4936105609?check_suite_focus=true

![スクリーンショット 2022-01-25 20 35 10](https://user-images.githubusercontent.com/82332/150970175-62f87fd3-df49-447d-915f-95f003191de1.png)



> NOTE: I've changed the release to pre-release as it's dummy and planning to delete both the dummy release and tag as soon as the PR is merged